### PR TITLE
Harden neural-network learning pipeline

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,19 @@
 - Recorded-sample training now snapshots trace metadata once per training step, caches decoded
   screenshots, assembles batches on CPU, and prefetches the next batch while DDP computes.
   Step-local cache preparation no longer rescans and rereads every historical screenshot.
+- Training now requires a complete global batch of newly recorded traces. The new-trace count bounds
+  each invocation to duplicate-free updates over the frozen replay snapshot, and a successfully
+  trained trace-count high-water mark prevents an unchanged replay set from triggering again.
+- Next-state crop augmentation retries random crops until a valid action remains visible, then uses
+  an action-centred fallback. Empty next-action masks explicitly produce a zero Double-DQN bootstrap
+  target instead of selecting an invalid flattened cell.
+- The loss now includes a configurable conservative-Q margin penalty for unsupported valid actions,
+  enabled by default with weight and margin `0.1`. Its contribution is recorded as
+  `conservative_q_loss` in training results, stored training records, and progress telemetry.
+- Exploration now uses independent stages: `random` controls action-catalog-weighted behavior that
+  bypasses inference, while `weighted_random` conditionally selects Q-weighted sampling after model
+  evaluation. These settings are no longer ordered thresholds, and the uniform-random interval has
+  been removed.
 - Every run records pipeline/resource JSONL telemetry and rank-zero training progress, including
   assembly, transfer, optimizer, checkpoint, GPU-memory, worker, and end-to-end throughput metrics.
   `kwola status RUN_DIR` reports live rates, in-flight workers, and recent CPU/GPU utilization.

--- a/README.md
+++ b/README.md
@@ -42,8 +42,33 @@ The built-in profiles are `testing`, `standard`, and `rig`. `rig` is the default
 feeds both GPUs from eight parallel browser environments. It budgets two CPU threads per browser
 and four per training rank on the 32-thread reference host, uses a measured batch of 48 per GPU,
 caches decoded screenshots in RAM, and prefetches CPU batches while the GPUs optimize. `standard`
-preserves the conservative two-rank reference configuration. Pass `--gpu INDEX` for an explicit
+preserves the lower-throughput two-rank reference configuration. Pass `--gpu INDEX` for an explicit
 single-GPU step.
+
+## Learning behavior
+
+TraceNet predicts separate immediate-reward and discounted-future-reward maps over the valid spatial
+action catalog. Their sum drives inference. Training uses masked Double DQN, with the online network
+selecting the next valid action and the target network evaluating it. Terminal transitions and next
+states with no valid action receive no bootstrap value.
+
+Automatic training starts only after the greater of `orchestration.minimum_traces_before_training`
+and one configured global batch (`training.batch_size * training.world_size`) of new traces has
+arrived. New traces determine the maximum number of duplicate-free updates in that invocation, while
+those updates sample from the entire frozen replay snapshot. A successful step persists the
+snapshot's trace-count high-water mark, so the same unchanged replay set cannot trigger training
+again. An explicit single-GPU `train-step` uses one local batch as its minimum.
+
+Current-state crops remain action-centred with configured jitter. Next-state crops are sampled
+randomly, retried until at least one valid action is visible, and fall back to an action-centred crop.
+The default conservative-Q term (`training.losses.conservative_q = 0.1`, margin `0.1`) penalizes the
+highest valid action outside the demonstrated region when it exceeds the demonstrated Q value minus
+the margin; set its weight to `0` to disable it.
+
+Exploration uses two independent decisions. `random` is the probability of bypassing the model for
+action-catalog-weighted random behavior. Otherwise the model runs, and `weighted_random` is the
+conditional probability of sampling from its valid Q map instead of taking the greedy maximum.
+Forced-random steps and runs without a checkpoint use action-catalog-weighted random behavior.
 
 Every run contains strictly validated `kwola.json` and `manifest.json` files, an LMDB database,
 content-addressed blobs, disposable prepared-sample cache records, reports, logs, and atomically

--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -63,11 +63,18 @@ browser, proxy, Babel, or training workers remain.
 The deterministic learning gate includes a terminal bandit where greedy Q converges on the better
 action and a two-step task where the terminal reward propagates into the first action's future map.
 Unit evidence must also cover exact masked Double-DQN targets, campaign-wide atomic coverage claims,
-instrumentation absence, ordered exploration thresholds, replay coverage/shuffling/rank disjointness,
-varied persistent crop augmentation, and strict checkpoint round trips. Training telemetry records
-the present and future losses, selected Q, bootstrap target, absolute TD error, and gradient norm.
+instrumentation absence, independent two-stage exploration, replay coverage/shuffling/rank
+disjointness, fresh-global-batch gating and high-water persistence, bounded update counts,
+validity-preserving next-state crops, zero bootstrap for empty next-action masks, conservative-Q
+margin behavior, varied persistent crop augmentation, and strict checkpoint round trips. Training
+telemetry records the present, future, and conservative-Q losses, selected Q, bootstrap target,
+absolute TD error, and gradient norm.
 
 ## Schema-v2 measured results (2026-08-30)
+
+These measurements predate the fresh-trace replay budget described above. The 600-iteration steps are
+retained as historical throughput evidence; they do not describe the current per-invocation training
+cadence and do not prove the new learning-hardening requirements.
 
 - The final source passed Ruff formatting/linting, strict mypy over 91 Python sources, and the full
   suite on both macOS and the Linux rig: 189 passed, two opt-in tests skipped, and 88.45%/88.72%
@@ -91,6 +98,15 @@ the present and future losses, selected Q, bootstrap target, absolute TD error, 
   the loaded window the GPUs averaged 73.1% and 71.3%, host CPU averaged 38.1% with a 100% peak, no
   swap or I/O wait occurred, and the pipeline retained ample RAM. The intentional interrupt recorded
   `pipeline_stopped`; the final scan found no browser, proxy, instrumentation, or training workers.
+
+## Post-review learning verification (2026-08-30)
+
+After the replay, crop-validity, and conservative-Q changes, the macOS working tree passed Ruff
+formatting and linting, strict mypy over 94 Python sources, and the non-network unit,
+characterization, and architecture suite: 194 passed with 87.44% branch-aware coverage. Four
+full-suite integration cases that bind local listening sockets could not execute in the restricted
+local sandbox. This is local correctness evidence only; it does not replace the required fresh Linux
+rig acceptance run or its two-GPU/browser performance evidence.
 
 The unchanged performance gates are at least 145 samples/second, no more than 1.35 seconds median
 optimizer time, and no more than 5 GiB peak VRAM. The 1.0.0 measurements above are historical

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,7 +33,14 @@ kwola CLI
 Testing workers immediately receive another browser session when they finish; the trainer has no
 barrier with them. Each training invocation freezes the current trace snapshot and creates a seeded
 shuffle from the run seed, training-step index, and replay epoch. DDP ranks consume disjoint slices
-of that common permutation, and a new permutation begins only after every trace has been offered.
+of that common permutation. Automatic training waits for at least the greater of
+`orchestration.minimum_traces_before_training` and one complete configured global batch of newly
+recorded traces. New traces provide the update budget, while sample indexes come from the complete
+frozen replay snapshot. The invocation runs no more than
+`floor(new_traces / (batch_size * world_size))` updates or the scheduled count, whichever is smaller,
+so it never crosses a permutation boundary. After success, the current trace count is persisted as a
+high-water mark; an unchanged replay set cannot train again. Explicit single-device training applies
+the same rule with a world size of one.
 The parent prepares one shared-memory CPU batch per rank; each rank then keeps a decoded-image LRU and
 builds the next CPU batch on a prefetch thread while the current batch computes. Gradients synchronize
 through DDP. After a final barrier, only rank 0 writes the training record and atomically publishes a
@@ -58,21 +65,29 @@ Its order defines both TraceNet output channels and recorded action indexes. Inf
 assembly share the legacy screenshot transform: grayscale, aspect-preserving configured downscale,
 dimensions rounded upward to a multiple of eight, and values rounded to two decimals. Current-state
 training crops are seeded and action-centred; next-state crops use a separately seeded random centre.
+Next-state augmentation makes up to eight random attempts to keep at least one valid action visible,
+then uses an action-centred fallback. A trace with no valid action even in that fallback is rejected.
 Images, action masks, reward masks, coordinates, and recent-action features are cropped together.
 
 TraceNet retains separate immediate- and discounted-future reward maps. Their masked sum is the
 action-value map used directly by greedy inference. Training uses masked Double DQN: the online model
 selects the next valid spatial action, the target model evaluates it, terminal transitions receive a
-zero future target, and both reward heads train immediately with Smooth L1 loss. Optional cursor,
-execution-feature, and future-symbol auxiliaries remain; the future-symbol target is detached.
-Gradients are clipped and target checkpoints refresh on the configured global iteration cadence.
+zero future target, and an empty next-action mask also produces zero bootstrap value. Both reward
+heads train immediately with Smooth L1 loss. Optional cursor, execution-feature, and future-symbol
+auxiliaries remain; the future-symbol target is detached. A conservative margin loss lowers the
+highest valid action outside the demonstrated region until it is at least the configured margin below
+the demonstrated Q value, limiting offline-Q extrapolation without raising the demonstrated value.
+Its default weight and margin are both `0.1`; a zero weight disables it. Gradients are clipped and
+target checkpoints refresh on the configured global iteration cadence.
 
-Exploration probabilities are ordered thresholds: weighted random occupies the first interval,
-uniform random the remainder of the total-random interval, and greedy Q selection the rest. Forced
-random testing remains weighted. Branch novelty is claimed atomically in a campaign-wide LMDB
-collection before each trace is committed. Initial-page coverage is claimed without reward. Code and
-no-code shaping applies only when branch instrumentation was available; screenshot and URL novelty
-remain session-local.
+Exploration has two independent stages. The scheduled `random` probability first decides whether to
+bypass inference and use action-catalog-weighted random behavior. If the model runs, a second draw
+against `weighted_random` chooses between Q-weighted sampling over valid model outputs and the greedy
+maximum. The probabilities are conditional rather than ordered intervals and either may exceed the
+other. Forced-random testing and inference without a checkpoint use action-catalog-weighted random
+behavior. Branch novelty is claimed atomically in a campaign-wide LMDB collection before each trace
+is committed. Initial-page coverage is claimed without reward. Code and no-code shaping applies only
+when branch instrumentation was available; screenshot and URL novelty remain session-local.
 
 ## Run layout
 
@@ -125,6 +140,8 @@ teardown. Browser and proxy lifecycles are context-managed and idempotently clos
 
 The pipeline telemetry stream records worker submission/completion and periodic host, process-tree,
 memory, and NVIDIA GPU samples. Rank zero emits progress during long training steps with separate
-assembly, host-to-device transfer, optimizer, memory, and end-to-end rates. These append-only records
-remain readable while a run is active through `kwola status`, including per-slot retry counts,
-backoff delay, and the latest worker error.
+assembly, host-to-device transfer, optimizer, memory, and end-to-end rates. Training results and
+stored step records include present, future, and conservative-Q losses; mean selected Q, mean
+bootstrap target, mean absolute TD error, and gradient norm. These append-only records remain
+readable while a run is active through `kwola status`, including per-slot retry counts, backoff delay,
+and the latest worker error.

--- a/kwola/agent/exploration.py
+++ b/kwola/agent/exploration.py
@@ -1,4 +1,4 @@
-"""The historical three-axis exploration schedule as a pure service."""
+"""Three-axis schedule producing independent random and Q-weighted probabilities."""
 
 import math
 from dataclasses import dataclass
@@ -10,10 +10,6 @@ from kwola.config.models import ExplorationAxisConfig, ExplorationConfig
 class ExplorationProbabilities:
     random: float
     weighted_random: float
-
-    def __post_init__(self) -> None:
-        if self.weighted_random > self.random:
-            raise ValueError("weighted-random probability cannot exceed total random probability")
 
 
 class ExplorationSchedule:

--- a/kwola/agent/policy.py
+++ b/kwola/agent/policy.py
@@ -26,7 +26,6 @@ class InferencePolicy:
         self._random = source
         self._channels = action_catalog(config.policy)
         self._weighted_random_policy = RandomActionPolicy(source, self._channels, weighted=True)
-        self._uniform_random_policy = RandomActionPolicy(source, self._channels, weighted=False)
         self._schedule = ExplorationSchedule(
             config.policy.exploration, config.policy.testing_sequence_length
         )
@@ -65,18 +64,15 @@ class InferencePolicy:
             session_count=1,
             test_step_index=test_step_index,
         )
-        draw = self._random.random()
         evaluation: tuple[TraceNetRequest, dict[str, torch.Tensor]] | None = None
-        if force_random or self._model is None or draw < exploration.weighted_random:
+        if force_random or self._model is None:
             action = self._weighted_random_policy.select(observation.action_map)
-        elif draw < exploration.random:
-            action = self._uniform_random_policy.select(observation.action_map)
+        elif self._random.random() < exploration.random:
+            action = self._weighted_random_policy.select(observation.action_map)
         else:
-            if capture_diagnostics:
-                evaluation = self._evaluate_model(observation, action_index, True)
-                action = self._action_from_output(observation, evaluation[1])
-            else:
-                action = self._model_action(observation, action_index)
+            evaluation = self._evaluate_model(observation, action_index, capture_diagnostics)
+            weighted = self._random.random() < exploration.weighted_random
+            action = self._action_from_output(observation, evaluation[1], weighted=weighted)
         if capture_diagnostics:
             if evaluation is None:
                 evaluation = self._diagnostic_evaluation(observation, action_index)
@@ -148,10 +144,6 @@ class InferencePolicy:
         model.load_state_dict(payload["model"], strict=True)  # type: ignore[arg-type]
         return model.eval()
 
-    def _model_action(self, observation: Observation, action_index: int) -> Action:
-        _request, output = self._evaluate_model(observation, action_index, False)
-        return self._action_from_output(observation, output)
-
     def _evaluate_model(
         self, observation: Observation, action_index: int, output_stamp: bool
     ) -> tuple[TraceNetRequest, dict[str, torch.Tensor]]:
@@ -189,9 +181,15 @@ class InferencePolicy:
         self,
         observation: Observation,
         output: dict[str, torch.Tensor],
+        *,
+        weighted: bool = False,
     ) -> Action:
         action_values = output["actionValues"][0]
-        flat = int(action_values.flatten().argmax())
+        flat = self._weighted_flat_index(action_values) if weighted else None
+        if weighted and flat is None:
+            return self._weighted_random_policy.select(observation.action_map)
+        if flat is None:
+            flat = int(action_values.flatten().argmax())
         height, width = action_values.shape[-2:]
         pixels = height * width
         channel = self._channels[flat // pixels]
@@ -211,9 +209,41 @@ class InferencePolicy:
             action_y,
             generated,
             channel.direction,
-            "model",
+            "weighted_random" if weighted else "model",
             channel.name,
         )
+
+    def _weighted_flat_index(self, action_values: torch.Tensor) -> int | None:
+        values = action_values.flatten()
+        valid = torch.isfinite(values) & (values > torch.finfo(values.dtype).min)
+        valid_indexes = torch.nonzero(valid, as_tuple=False).flatten()
+        if valid_indexes.numel() == 0:
+            return None
+        candidates = values[valid]
+        minimum = candidates.min()
+        maximum = candidates.max()
+        if float(maximum) > 0:
+            weights = (
+                (candidates - minimum).square()
+                if float(minimum) > 0
+                else candidates.clamp_min(0).square()
+            )
+        else:
+            weights = (candidates - minimum).square()
+        total = weights.sum()
+        if not torch.isfinite(total) or float(total) <= 0:
+            return None
+        threshold = self._random.random() * float(total)
+        cumulative = weights.cumsum(0)
+        position = int(
+            torch.searchsorted(
+                cumulative,
+                torch.tensor(threshold, dtype=weights.dtype, device=weights.device),
+                right=True,
+            )
+        )
+        position = min(position, valid_indexes.numel() - 1)
+        return int(valid_indexes[position])
 
     def _predicted(
         self, output: dict[str, torch.Tensor], observation: Observation

--- a/kwola/browser/session.py
+++ b/kwola/browser/session.py
@@ -114,6 +114,7 @@ class BrowserSessionCoordinator:
             errors=_errors(console, network),
             branch_trace_available=branches.available,
             application_fitness=self._application_fitness(),
+            network_event_count=len(network),
         )
 
     def _collect_branches(self) -> BranchTraceSnapshot:

--- a/kwola/config/models.py
+++ b/kwola/config/models.py
@@ -113,14 +113,6 @@ class ExplorationAxisConfig(StrictModel):
     start_weighted_random_rate: float = Field(default=1.0, ge=0, le=1)
     end_weighted_random_rate: float = Field(default=1.0, ge=0, le=1)
 
-    @model_validator(mode="after")
-    def weighted_exploration_is_within_total(self) -> Self:
-        if self.start_weighted_random_rate > self.start_random_rate:
-            raise ValueError("start weighted-random rate cannot exceed total random rate")
-        if self.end_weighted_random_rate > self.end_random_rate:
-            raise ValueError("end weighted-random rate cannot exceed total random rate")
-        return self
-
 
 class ExplorationConfig(StrictModel):
     action: ExplorationAxisConfig = ExplorationAxisConfig(
@@ -267,6 +259,8 @@ class LossConfig(StrictModel):
     execution_trace: float = Field(default=1.0, ge=0)
     discounted_future_reward: float = Field(default=8.0, ge=0)
     present_reward: float = Field(default=16.0, ge=0)
+    conservative_q: float = Field(default=0.1, ge=0)
+    conservative_q_margin: float = Field(default=0.1, ge=0)
 
 
 class TrainingConfig(StrictModel):

--- a/kwola/domain/observations.py
+++ b/kwola/domain/observations.py
@@ -28,3 +28,4 @@ class Observation:
     errors: tuple[str, ...] = ()
     branch_trace_available: bool = False
     application_fitness: float | None = None
+    network_event_count: int | None = None

--- a/kwola/orchestration/experiment.py
+++ b/kwola/orchestration/experiment.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from kwola.config import load_config
 from kwola.storage import LmdbRunStore
+from kwola.training.replay import minimum_replay_size
 
 from .messages import ArtifactReference, WorkerCommand, WorkerResult
 from .results import RunnerResult
@@ -222,16 +223,25 @@ class ExperimentRunner:
         )
 
     def _training_ready(self) -> bool:
-        return self._trace_count() >= self._config.orchestration.minimum_traces_before_training
+        replay_minimum = minimum_replay_size(
+            self._config.training.batch_size, self._config.training.world_size
+        )
+        required = max(self._config.orchestration.minimum_traces_before_training, replay_minimum)
+        trace_count, trained_trace_count = self._trace_state()
+        return trace_count - trained_trace_count >= required
 
-    def _trace_count(self) -> int:
+    def _trace_state(self) -> tuple[int, int]:
         database = self._run_dir / self._config.storage.database_directory
         with LmdbRunStore(
             database,
             map_size=self._config.storage.database_map_size_bytes,
             readonly=True,
         ) as store:
-            return sum(1 for _ in store.scan("traces"))
+            state = store.get("run", "state") or {}
+            return (
+                sum(1 for _ in store.scan("traces")),
+                int(state.get("training_trace_count", 0)),
+            )
 
     @staticmethod
     def _record_completion(

--- a/kwola/orchestration/trace_recorder.py
+++ b/kwola/orchestration/trace_recorder.py
@@ -1,7 +1,7 @@
 """Recorded-trace persistence and reward feature ownership."""
 
 import hashlib
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -18,6 +18,7 @@ class NoveltyState:
     screenshots: set[str]
     urls: set[str]
     errors: set[str]
+    branches: set[int]
 
     @classmethod
     def initial(cls, observation: Observation) -> "NoveltyState":
@@ -26,6 +27,7 @@ class NoveltyState:
             {digest},
             {observation.url},
             set(observation.errors),
+            set(observation.branch_symbols),
         )
 
 
@@ -39,6 +41,7 @@ class TraceFeatures:
     url_changed: bool
     url_new: bool
     log_output: bool
+    network_traffic: bool
 
 
 class TraceRecorder:
@@ -83,18 +86,16 @@ class TraceRecorder:
         }
 
         def build(claimed: tuple[str, ...]) -> dict[str, Any]:
-            completed = replace(
-                features,
-                new_branches=tuple(sorted(symbols_by_key[key] for key in claimed)),
-            )
-            reward = _reward(self._config, after, completed)
+            campaign_new_branches = tuple(sorted(symbols_by_key[key] for key in claimed))
+            reward = _reward(self._config, after, features)
             return self._payload(
                 step_id,
                 index,
                 action,
                 before,
                 after,
-                completed,
+                features,
+                campaign_new_branches,
                 reward,
                 cursor,
                 screenshots,
@@ -165,6 +166,7 @@ class TraceRecorder:
         before: Observation,
         after: Observation,
         features: TraceFeatures,
+        campaign_new_branches: tuple[int, ...],
         reward: float,
         cursor: str,
         screenshots: tuple[str, str],
@@ -184,8 +186,10 @@ class TraceRecorder:
             "errors": list(after.errors),
             "new_errors": list(features.new_errors),
             "new_branch_symbols": list(features.new_branches),
+            "campaign_new_branch_symbols": list(campaign_new_branches),
             "branch_trace_available": after.branch_trace_available,
             "new_network_symbols": list(features.new_network),
+            "network_traffic": features.network_traffic,
             "screenshot_changed": features.screenshot_changed,
             "screenshot_new": features.screenshot_new,
             "url_new": features.url_new,
@@ -201,11 +205,16 @@ class TraceRecorder:
 
 
 def _features(before: Observation, after: Observation, state: NoveltyState) -> TraceFeatures:
+    new_branches = (
+        tuple(sorted(set(after.branch_symbols) - state.branches))
+        if after.branch_trace_available
+        else ()
+    )
     new_network = tuple(sorted(set(after.network_symbols) - set(before.network_symbols)))
     new_errors = tuple(sorted(set(after.errors) - state.errors))
     digest = hashlib.sha256(after.screenshot).hexdigest()
     result = TraceFeatures(
-        (),
+        new_branches,
         new_network,
         new_errors,
         before.screenshot != after.screenshot,
@@ -213,11 +222,20 @@ def _features(before: Observation, after: Observation, state: NoveltyState) -> T
         before.url != after.url,
         after.url not in state.urls,
         len(after.console_messages) > len(before.console_messages),
+        _network_traffic(before, after, new_network),
     )
     state.screenshots.add(digest)
     state.urls.add(after.url)
     state.errors.update(after.errors)
+    if after.branch_trace_available:
+        state.branches.update(after.branch_symbols)
     return result
+
+
+def _network_traffic(before: Observation, after: Observation, new_network: tuple[int, ...]) -> bool:
+    if before.network_event_count is None or after.network_event_count is None:
+        return bool(new_network)
+    return after.network_event_count > before.network_event_count
 
 
 def _reward(config: RunConfig, after: Observation, features: TraceFeatures) -> float:
@@ -226,7 +244,7 @@ def _reward(config: RunConfig, after: Observation, features: TraceFeatures) -> f
             branch_trace_available=after.branch_trace_available,
             code_executed=bool(after.branch_symbols),
             new_branches_executed=bool(features.new_branches),
-            network_traffic=bool(after.network_symbols),
+            network_traffic=features.network_traffic,
             new_network_traffic=bool(features.new_network),
             screenshot_changed=features.screenshot_changed,
             screenshot_new=features.screenshot_new,

--- a/kwola/orchestration/training.py
+++ b/kwola/orchestration/training.py
@@ -26,7 +26,7 @@ from kwola.training.optimizer import (
     OptimizerMetrics,
     summarize_optimizer_metrics,
 )
-from kwola.training.replay import ReplaySampler
+from kwola.training.replay import ReplaySampler, require_replay_iterations
 from kwola.training.samples import RecordedSampleAssembler
 
 from .lifecycle import RunnerLifecycle
@@ -69,10 +69,18 @@ class TrainingRunner:
         if gpu is not None:
             torch.cuda.set_device(gpu)
         with self._store() as store:
-            step_index, trace_count, training_index, iteration_count = self._state(store)
+            step_index, trace_count, trained_trace_count, training_index, iteration_count = (
+                self._state(store)
+            )
             if trace_count == 0:
                 raise RuntimeError("training requires at least one recorded browser trace")
             self._assembler(store).prepare_cache(self._config.training.sample_cache_workers)
+        iteration_count = require_replay_iterations(
+            trace_count - trained_trace_count,
+            iteration_count,
+            self._config.training.batch_size,
+            1,
+        )
         step_id = f"training-{step_index:08d}"
         model = TraceNet(
             self._config.model, num_actions=len(action_catalog(self._config.policy))
@@ -95,6 +103,7 @@ class TrainingRunner:
             step_id,
             metrics,
             iteration_count,
+            trace_count,
         )
         return RunnerResult(
             status="completed",
@@ -111,6 +120,7 @@ class TrainingRunner:
                 "mean_bootstrap_target": metrics.mean_bootstrap_target,
                 "mean_absolute_td_error": metrics.mean_absolute_td_error,
                 "gradient_norm": metrics.gradient_norm,
+                "conservative_q_loss": metrics.conservative_q_loss,
             },
         )
 
@@ -222,11 +232,12 @@ class TrainingRunner:
         target_model.load_state_dict(payload["target_model"], strict=True)  # type: ignore[arg-type]
         optimizer.optimizer.load_state_dict(payload["optimizer"])  # type: ignore[arg-type]
 
-    def _state(self, store: LmdbRunStore) -> tuple[int, int, int, int]:
+    def _state(self, store: LmdbRunStore) -> tuple[int, int, int, int, int]:
         state = store.get("run", "state") or {}
         return (
             int(state.get("training_steps", 0)),
             sum(1 for _ in store.scan("traces")),
+            int(state.get("training_trace_count", 0)),
             int(state.get("training_iterations", 0)),
             int(
                 state.get(
@@ -236,13 +247,16 @@ class TrainingRunner:
             ),
         )
 
-    def _record(self, step_id: str, metrics: OptimizerMetrics, iterations: int) -> None:
+    def _record(
+        self, step_id: str, metrics: OptimizerMetrics, iterations: int, trace_count: int
+    ) -> None:
         with self._store() as store:
 
             def complete(current: dict[str, Any] | None) -> dict[str, Any]:
                 state = dict(current or {})
                 state["training_steps"] = int(state.get("training_steps", 0)) + 1
                 state["training_iterations"] = int(state.get("training_iterations", 0)) + iterations
+                state["training_trace_count"] = trace_count
                 return state
 
             store.update("run", "state", complete)
@@ -259,6 +273,7 @@ class TrainingRunner:
                     "mean_bootstrap_target": metrics.mean_bootstrap_target,
                     "mean_absolute_td_error": metrics.mean_absolute_td_error,
                     "gradient_norm": metrics.gradient_norm,
+                    "conservative_q_loss": metrics.conservative_q_loss,
                     "iterations": iterations,
                     "status": "completed",
                 },

--- a/kwola/training/crop_selection.py
+++ b/kwola/training/crop_selection.py
@@ -1,0 +1,44 @@
+"""Validity-preserving crop selection for bootstrapped next states."""
+
+import random
+from collections.abc import Mapping
+from typing import Any
+
+from kwola.domain.actions import ActionChannel
+
+from .action_masks import action_masks
+from .geometry import Crop, centered_crop, effective_crop, random_crop
+from .sample_features import scaled_action
+
+
+def valid_next_crop(
+    trace: Mapping[str, Any],
+    image_width: int,
+    image_height: int,
+    crop_width: int,
+    crop_height: int,
+    channels: tuple[ActionChannel, ...] | None,
+    source: random.Random,
+) -> Crop:
+    """Sample next-state augmentation without hiding every valid action."""
+    for _attempt in range(8):
+        crop = effective_crop(
+            random_crop(image_width, image_height, crop_width, crop_height, source)
+        )
+        if bool(action_masks(trace, (image_width, image_height), channels, crop=crop).any()):
+            return crop
+
+    action_x, action_y = scaled_action(trace, (image_width, image_height))
+    fallback = effective_crop(
+        centered_crop(
+            action_x,
+            action_y,
+            image_width,
+            image_height,
+            crop_width,
+            crop_height,
+        )
+    )
+    if bool(action_masks(trace, (image_width, image_height), channels, crop=fallback).any()):
+        return fallback
+    raise ValueError("recorded next state has no valid action inside an action-centred crop")

--- a/kwola/training/distributed.py
+++ b/kwola/training/distributed.py
@@ -1,4 +1,4 @@
-"""Two-rank recorded-sample training with explicit DDP ownership."""
+"""Multi-rank recorded-sample training with explicit DDP ownership."""
 
 import copy
 import multiprocessing
@@ -30,7 +30,8 @@ from .assembler_factory import recorded_sample_assembler
 from .batch_stream import batches
 from .ddp import DistributedCoordinator, DistributedSettings
 from .optimizer import ModelOptimizer, OptimizerMetrics, summarize_optimizer_metrics
-from .replay import ReplaySampler
+from .replay import ReplaySampler, require_replay_iterations
+from .replay_state import require_new_replay as _prepare_cache
 from .samples import RecordedSampleAssembler, TrainingBatch
 from .spool import batch_to_device, share_batch
 from .telemetry import record_training_progress
@@ -64,12 +65,6 @@ def run_distributed_training(run_dir: Path) -> RunnerResult:
         join=True,
     )
     return RunnerResult.model_validate_json(results.get())
-
-
-def _prepare_cache(run_dir: Path) -> None:
-    with _store(run_dir, readonly=True) as store:
-        if not any(True for _ in store.scan("traces")):
-            raise RuntimeError("training requires at least one recorded browser trace")
 
 
 def _shared_initial_batches(run_dir: Path) -> tuple[TrainingBatch, ...]:
@@ -124,6 +119,7 @@ def _training_rank(
             target,
             optimizer,
             step_index,
+            trace_count,
             iterations,
             assembly_seconds,
             transfer_seconds,
@@ -138,6 +134,7 @@ def _training_rank(
                 target,
                 optimizer,
                 step_index,
+                trace_count,
                 metrics,
                 float(loss.item() / world_size),
                 time.perf_counter() - started,
@@ -152,15 +149,24 @@ def _rank_step(
     run_dir: Path,
     coordinator: DistributedCoordinator,
     initial_batch: TrainingBatch | None = None,
-) -> tuple[OptimizerMetrics, TraceNet, TraceNet, ModelOptimizer, int, int, float, float]:
+) -> tuple[OptimizerMetrics, TraceNet, TraceNet, ModelOptimizer, int, int, int, float, float]:
     config = load_config(run_dir)
     manifest = load_manifest(run_dir)
     with _store(run_dir, readonly=True) as store:
         state = store.get("run", "state") or {}
         step_index = int(state.get("training_steps", 0))
         training_index = int(state.get("training_iterations", 0))
-        iteration_count = int(
+        requested_iterations = int(
             state.get("scheduled_training_iterations", config.training.batches_per_iteration)
+        )
+        trace_count = sum(1 for _ in store.scan("traces"))
+        trained_trace_count = int(state.get("training_trace_count", 0))
+        iteration_count = require_replay_iterations(
+            trace_count - trained_trace_count,
+            requested_iterations,
+            config.training.batch_size,
+            config.training.world_size,
+            "distributed training",
         )
     model = TraceNet(config.model, num_actions=len(action_catalog(config.policy))).to(
         coordinator.device
@@ -192,6 +198,7 @@ def _rank_step(
         target,
         optimizer,
         step_index,
+        trace_count,
         iteration_count,
         assembly_seconds,
         transfer_seconds,
@@ -312,6 +319,7 @@ def _record_progress(
         mean_bootstrap_target=(sum(item.mean_bootstrap_target for item in results) / completed),
         mean_absolute_td_error=(sum(item.mean_absolute_td_error for item in results) / completed),
         gradient_norm=sum(item.gradient_norm for item in results) / completed,
+        conservative_q_loss=sum(item.conservative_q_loss for item in results) / completed,
         gpu_memory_allocated_bytes=torch.cuda.memory_allocated(coordinator.device),
         gpu_memory_reserved_bytes=torch.cuda.memory_reserved(coordinator.device),
     )
@@ -323,6 +331,7 @@ def _publish_result(
     target: TraceNet,
     optimizer: ModelOptimizer,
     step_index: int,
+    trace_count: int,
     metrics: OptimizerMetrics,
     mean_loss: float,
     duration: float,
@@ -358,6 +367,7 @@ def _publish_result(
         mean_loss,
         metrics,
         iterations,
+        trace_count,
         duration,
         assembly_seconds,
         transfer_seconds,
@@ -384,6 +394,7 @@ def _publish_result(
             "mean_bootstrap_target": metrics.mean_bootstrap_target,
             "mean_absolute_td_error": metrics.mean_absolute_td_error,
             "gradient_norm": metrics.gradient_norm,
+            "conservative_q_loss": metrics.conservative_q_loss,
         },
     )
 
@@ -410,6 +421,7 @@ def _record_step(
     loss: float,
     metrics: OptimizerMetrics,
     iterations: int,
+    trace_count: int,
     end_to_end_seconds: float,
     assembly_seconds: float,
     transfer_seconds: float,
@@ -422,6 +434,7 @@ def _record_step(
             state = dict(current or {})
             state["training_steps"] = index + 1
             state["training_iterations"] = int(state.get("training_iterations", 0)) + iterations
+            state["training_trace_count"] = trace_count
             return state
 
         store.update("run", "state", complete)
@@ -450,6 +463,7 @@ def _record_step(
                 "mean_bootstrap_target": metrics.mean_bootstrap_target,
                 "mean_absolute_td_error": metrics.mean_absolute_td_error,
                 "gradient_norm": metrics.gradient_norm,
+                "conservative_q_loss": metrics.conservative_q_loss,
                 "iterations": iterations,
                 "status": "completed",
                 "ranks": config.training.world_size,

--- a/kwola/training/losses.py
+++ b/kwola/training/losses.py
@@ -1,4 +1,4 @@
-"""Masked Double-DQN losses for TraceNet's decomposed value maps."""
+"""Masked Double-DQN and conservative offline-Q losses for TraceNet value maps."""
 
 from dataclasses import dataclass
 
@@ -15,6 +15,7 @@ class QLoss:
     total: Tensor
     present_reward: Tensor
     discounted_reward: Tensor
+    conservative_q: Tensor
     trace_prediction: Tensor
     execution_feature: Tensor
     cursor_prediction: Tensor
@@ -50,11 +51,13 @@ def q_learning_loss(
     present, future, selected_q, td_error = _value_losses(
         outputs, batch, future_targets, config.losses
     )
+    conservative = _conservative_q_loss(outputs, batch, selected_q, config.losses)
     auxiliary = _auxiliary_losses(outputs, batch, config.losses)
     return QLoss(
-        total=present + future + sum(auxiliary),
+        total=present + future + conservative + sum(auxiliary),
         present_reward=present,
         discounted_reward=future,
+        conservative_q=conservative,
         trace_prediction=auxiliary[0],
         execution_feature=auxiliary[1],
         cursor_prediction=auxiliary[2],
@@ -102,6 +105,38 @@ def _value_losses(
     )
 
 
+def _conservative_q_loss(
+    outputs: dict[str, Tensor],
+    batch: TrainingBatch,
+    selected_q: Tensor,
+    weights: LossConfig,
+) -> Tensor:
+    """Keep unsupported valid actions below the demonstrated action value."""
+    values = outputs["actionValues"]
+    zero = values.sum() * 0
+    if weights.conservative_q == 0:
+        return zero
+
+    valid = batch.request.pixel_action_maps > 0
+    indexes = torch.arange(len(batch.sample_ids), device=values.device)
+    demonstrated = torch.zeros_like(valid)
+    demonstrated_region = (
+        _reward_masks(batch, values)
+        * batch.request.pixel_action_maps[indexes, batch.action_indexes]
+    ) > 0
+    demonstrated[indexes, batch.action_indexes] = demonstrated_region
+    alternatives = valid & ~demonstrated
+    has_alternative = alternatives.flatten(1).any(dim=1)
+    alternative_max = values.masked_fill(~alternatives, torch.finfo(values.dtype).min)
+    alternative_max = alternative_max.flatten(1).amax(dim=1)
+    penalties = nn.functional.relu(
+        alternative_max - selected_q.detach() + weights.conservative_q_margin
+    )
+    penalties = penalties * has_alternative.type_as(penalties)
+    count = has_alternative.sum().clamp_min(1)
+    return penalties.sum() / count * weights.conservative_q + zero
+
+
 def _double_dqn_targets(
     model: nn.Module,
     target_model: nn.Module,
@@ -119,7 +154,9 @@ def _double_dqn_targets(
             best_actions = online_values.flatten(1).argmax(dim=1)
             selected = target_values.flatten(1).gather(1, best_actions[:, None])[:, 0]
             discounted = torch.clamp(selected * discount_rate, min=-maximum, max=maximum)
-            return discounted * batch.next_state_valid.type_as(discounted)
+            has_valid_action = batch.next_request.pixel_action_maps.flatten(1).gt(0).any(dim=1)
+            valid_bootstrap = batch.next_state_valid & has_valid_action
+            return discounted * valid_bootstrap.type_as(discounted)
     finally:
         if model_was_training:
             model.train()

--- a/kwola/training/optimizer.py
+++ b/kwola/training/optimizer.py
@@ -25,6 +25,7 @@ class OptimizerMetrics:
     mean_bootstrap_target: float = 0.0
     mean_absolute_td_error: float = 0.0
     gradient_norm: float = 0.0
+    conservative_q_loss: float = 0.0
 
 
 def summarize_optimizer_metrics(
@@ -42,6 +43,7 @@ def summarize_optimizer_metrics(
         mean_bootstrap_target=sum(result.mean_bootstrap_target for result in results) / count,
         mean_absolute_td_error=sum(result.mean_absolute_td_error for result in results) / count,
         gradient_norm=sum(result.gradient_norm for result in results) / count,
+        conservative_q_loss=sum(result.conservative_q_loss for result in results) / count,
     )
 
 
@@ -116,4 +118,5 @@ class ModelOptimizer:
             mean_bootstrap_target=float(losses.mean_bootstrap_target.detach()),
             mean_absolute_td_error=float(losses.mean_absolute_td_error.detach()),
             gradient_norm=float(gradient_norm.detach()),
+            conservative_q_loss=float(losses.conservative_q.detach()),
         )

--- a/kwola/training/replay.py
+++ b/kwola/training/replay.py
@@ -1,6 +1,33 @@
-"""Deterministic shuffled replay with disjoint distributed-rank slices."""
+"""Fresh-data-bounded shuffled replay with disjoint distributed-rank slices."""
 
 import random
+
+
+def minimum_replay_size(batch_size: int, world_size: int) -> int:
+    """Return the samples required for one duplicate-free global update."""
+    return batch_size * world_size
+
+
+def bounded_replay_iterations(size: int, requested: int, batch_size: int, world_size: int) -> int:
+    """Limit updates to complete global batches covered by the new-data budget."""
+    complete_global_batches = size // minimum_replay_size(batch_size, world_size)
+    return min(requested, complete_global_batches)
+
+
+def require_replay_iterations(
+    size: int,
+    requested: int,
+    batch_size: int,
+    world_size: int,
+    label: str = "training",
+) -> int:
+    count = bounded_replay_iterations(size, requested, batch_size, world_size)
+    if count:
+        return count
+    required = minimum_replay_size(batch_size, world_size)
+    raise RuntimeError(
+        f"{label} requires at least {required} traces for one duplicate-free global batch"
+    )
 
 
 class ReplaySampler:

--- a/kwola/training/replay_state.py
+++ b/kwola/training/replay_state.py
@@ -1,0 +1,27 @@
+"""Persistent replay high-water state shared by training entry points."""
+
+from pathlib import Path
+
+from kwola.config import load_config
+from kwola.storage import LmdbRunStore
+
+from .replay import require_replay_iterations
+
+
+def require_new_replay(run_dir: Path) -> None:
+    config = load_config(run_dir)
+    with LmdbRunStore(
+        run_dir / config.storage.database_directory,
+        map_size=config.storage.database_map_size_bytes,
+        compression_level=config.storage.codec_compression_level,
+        readonly=True,
+    ) as store:
+        trace_count = sum(1 for _ in store.scan("traces"))
+        state = store.get("run", "state") or {}
+    require_replay_iterations(
+        trace_count - int(state.get("training_trace_count", 0)),
+        1,
+        config.training.batch_size,
+        config.training.world_size,
+        "training",
+    )

--- a/kwola/training/sample_features.py
+++ b/kwola/training/sample_features.py
@@ -184,6 +184,15 @@ def scaled_action(
     )
 
 
+def coordinate_tensors(
+    coordinates: Sequence[tuple[int, int]], device: torch.device
+) -> tuple[Tensor, Tensor]:
+    return (
+        torch.tensor([item[0] for item in coordinates], device=device),
+        torch.tensor([item[1] for item in coordinates], device=device),
+    )
+
+
 def reward_mask(
     trace: Mapping[str, Any],
     size: int | tuple[int, int],
@@ -224,7 +233,7 @@ def execution_features(trace: Mapping[str, Any]) -> tuple[float, ...]:
         float(bool(trace.get("new_errors"))),
         float(bool(trace.get("branch_symbols"))),
         float(bool(trace.get("new_branch_symbols"))),
-        float(bool(trace.get("network_symbols"))),
+        float(bool(trace.get("network_traffic", trace.get("network_symbols")))),
         float(bool(trace.get("new_network_symbols"))),
         float(bool(trace.get("screenshot_changed"))),
         float(bool(trace.get("screenshot_new"))),

--- a/kwola/training/samples.py
+++ b/kwola/training/samples.py
@@ -18,10 +18,12 @@ from kwola.storage import LmdbRunStore
 
 from .action_masks import cached_cropped_action_masks
 from .cache import SampleCache
-from .geometry import Crop, action_crop, centered_crop, effective_crop, random_crop
+from .crop_selection import valid_next_crop
+from .geometry import Crop, action_crop, centered_crop, effective_crop
 from .image_cache import DecodedImageCache
 from .sample_features import (
     action_index_for_trace,
+    coordinate_tensors,
     cursor_vector,
     execution_features,
     future_symbols,
@@ -220,7 +222,7 @@ class RecordedSampleAssembler:
             scaled_action(item.trace, (item.crop.width, item.crop.height), item.crop)
             for item in current
         ]
-        x, y = _coordinate_tensors(coordinates, device)
+        x, y = coordinate_tensors(coordinates, device)
         return TrainingBatch(
             request=request,
             next_request=next_request,
@@ -345,7 +347,14 @@ class RecordedSampleAssembler:
                 *desired,
             )
         else:
-            crop = random_crop(image.shape[1], image.shape[0], *desired, self._random)
+            crop = valid_next_crop(
+                trace,
+                image.shape[1],
+                image.shape[0],
+                *desired,
+                self._channels,
+                self._random,
+            )
         return _PreparedSample(key, trace, image, effective_crop(crop))
 
     @staticmethod
@@ -460,7 +469,7 @@ def _auxiliary_tensors(
             scaled_action(item.trace, (item.crop.width, item.crop.height), item.crop)
             for item in selected
         ]
-        x, y = _coordinate_tensors(coordinates, device)
+        x, y = coordinate_tensors(coordinates, device)
     indexes = None
     offsets = None
     weights = None
@@ -471,15 +480,6 @@ def _auxiliary_tensors(
         ]
         indexes, offsets, weights = weighted_symbol_bags(future, device)
     return _AuxiliaryTensors(enabled, actions, x, y, indexes, offsets, weights)
-
-
-def _coordinate_tensors(
-    coordinates: Sequence[tuple[int, int]], device: torch.device
-) -> tuple[Tensor, Tensor]:
-    return (
-        torch.tensor([item[0] for item in coordinates], device=device),
-        torch.tensor([item[1] for item in coordinates], device=device),
-    )
 
 
 def _attention_symbols(

--- a/tests/characterization/test_legacy_loss.py
+++ b/tests/characterization/test_legacy_loss.py
@@ -1,10 +1,12 @@
+from dataclasses import replace
+
 import torch
 from torch import Tensor, nn
 
 from kwola.agent.model_heads import TraceNetHeads
 from kwola.config import profile_config
 from kwola.training.batches import diagnostic_batch
-from kwola.training.losses import _double_dqn_targets, _value_losses
+from kwola.training.losses import _conservative_q_loss, _double_dqn_targets, _value_losses
 from kwola.training.samples import TrainingBatch
 
 
@@ -68,6 +70,47 @@ def test_double_dqn_clips_positive_and_negative_bootstraps_symmetrically() -> No
     )
 
     torch.testing.assert_close(targets, torch.tensor([10.0, -10.0]))
+
+
+def test_double_dqn_does_not_bootstrap_an_empty_nonterminal_action_mask() -> None:
+    batch = _batch(torch.tensor([True, True]))
+    empty_request = replace(
+        batch.next_request,
+        pixel_action_maps=torch.zeros_like(batch.next_request.pixel_action_maps),
+    )
+    batch = replace(batch, next_request=empty_request)
+    values = torch.full((2, 2, 8, 8), 100.0)
+
+    targets = _double_dqn_targets(
+        FixedModel({"actionValues": values}),
+        FixedModel({"actionValues": values}),
+        batch,
+        discount_rate=0.85,
+        maximum=10.0,
+    )
+
+    torch.testing.assert_close(targets, torch.zeros(2))
+
+
+def test_conservative_q_margin_lowers_the_best_unsupported_action() -> None:
+    config = profile_config("testing", "https://example.com", 1)
+    batch = _batch(torch.tensor([False, False]))
+    values = torch.zeros(2, 2, 8, 8, requires_grad=True)
+    with torch.no_grad():
+        values[0, 1, 0, 1] = 5.0
+        values[1, 0, 0, 1] = 4.0
+
+    loss = _conservative_q_loss(
+        {"actionValues": values}, batch, torch.zeros(2), config.training.losses
+    )
+    loss.backward()
+
+    assert loss > 0
+    assert values.grad is not None
+    assert values.grad[0, 1, 0, 1] > 0
+    assert values.grad[1, 0, 0, 1] > 0
+    assert values.grad[0, 0, 0, 0] == 0
+    assert values.grad[1, 1, 0, 0] == 0
 
 
 def test_present_reward_trains_on_terminal_and_only_recorded_region() -> None:

--- a/tests/unit/test_agent_characterization.py
+++ b/tests/unit/test_agent_characterization.py
@@ -129,6 +129,8 @@ def test_single_session_uses_midpoint_axis() -> None:
     )
 
 
-def test_exploration_thresholds_reject_weighted_probability_above_total() -> None:
-    with pytest.raises(ValueError, match="cannot exceed"):
-        ExplorationProbabilities(random=0.2, weighted_random=0.3)
+def test_weighted_exploration_probability_is_an_independent_second_stage() -> None:
+    probability = ExplorationProbabilities(random=0.2, weighted_random=0.3)
+
+    assert probability.random == 0.2
+    assert probability.weighted_random == 0.3

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -182,12 +182,6 @@ def test_credential_environment_references_are_validated_and_required(
             lambda data: data["instrumentation"].update(enabled=False, rewrite_javascript=True),
             "requires instrumentation",
         ),
-        (
-            lambda data: data["policy"]["exploration"]["action"].update(
-                start_random_rate=0.2, start_weighted_random_rate=0.3
-            ),
-            "weighted-random",
-        ),
     ),
 )
 def test_all_cross_field_constraints_are_actionable(mutation: object, message: str) -> None:

--- a/tests/unit/test_distributed_hardening.py
+++ b/tests/unit/test_distributed_hardening.py
@@ -66,6 +66,7 @@ def test_training_rank_reduces_and_publishes_rank_zero(
             object(),
             object(),
             5,
+            100,
             7,
             0.25,
             0.5,
@@ -115,6 +116,8 @@ def test_rank_step_builds_model_optimizer_and_uses_scheduled_iterations(
                 "scheduled_training_iterations": 3,
             },
         )
+        for index in range(12):
+            store.put("traces", f"trace-{index}", {"index": index})
     model = RankModel()
     monkeypatch.setattr(distributed_training, "TraceNet", lambda *_args, **_values: model)
     monkeypatch.setattr(distributed_training, "_load_models", lambda *_args: None)
@@ -148,7 +151,7 @@ def test_rank_step_builds_model_optimizer_and_uses_scheduled_iterations(
         "initial",  # type: ignore[arg-type]
     )
 
-    assert result[4:] == (4, 3, 0.4, 0.2)
+    assert result[4:] == (4, 12, 3, 0.4, 0.2)
     assert received == [(4, 20, 3, "initial")]
 
 
@@ -212,6 +215,7 @@ def test_shared_batches_progress_and_checkpoint_publication(
         target,  # type: ignore[arg-type]
         optimizer,  # type: ignore[arg-type]
         0,
+        4,
         OptimizerMetrics(1.5, 0.5, 8.0),
         1.5,
         2.0,
@@ -232,3 +236,4 @@ def test_shared_batches_progress_and_checkpoint_publication(
     assert state is not None
     assert state["training_steps"] == 1
     assert state["training_iterations"] == 2
+    assert state["training_trace_count"] == 4

--- a/tests/unit/test_experiment.py
+++ b/tests/unit/test_experiment.py
@@ -47,6 +47,27 @@ def test_pipeline_adapts_from_simultaneous_training_and_browser_results(
     assert adjustment[1]["browser_sample_count"] == 1
 
 
+def test_training_waits_for_one_duplicate_free_global_batch(tmp_path: Path) -> None:
+    initialize_run("https://example.com", "standard", tmp_path, 4)
+    runner = ExperimentRunner(tmp_path)
+    with LmdbRunStore(tmp_path / "run.lmdb") as store:
+        for index in range(47):
+            store.put("traces", f"trace-{index}", {"index": index})
+    assert not runner._training_ready()  # type: ignore[attr-defined]
+
+    with LmdbRunStore(tmp_path / "run.lmdb") as store:
+        store.put("traces", "trace-47", {"index": 47})
+    assert runner._training_ready()  # type: ignore[attr-defined]
+
+    with LmdbRunStore(tmp_path / "run.lmdb") as store:
+        store.update(
+            "run",
+            "state",
+            lambda current: {**(current or {}), "training_trace_count": 48},
+        )
+    assert not runner._training_ready()  # type: ignore[attr-defined]
+
+
 def test_adaptation_clamps_bounds_and_skips_empty_browser_window(tmp_path: Path) -> None:
     initialize_run("https://example.com", "testing", tmp_path, 4)
     runner = ExperimentRunner(tmp_path)

--- a/tests/unit/test_inference_policy.py
+++ b/tests/unit/test_inference_policy.py
@@ -36,6 +36,15 @@ class FixedDrawRandom(random.Random):
         return self._draw
 
 
+class SequenceDrawRandom(random.Random):
+    def __init__(self, *draws: float) -> None:
+        super().__init__(0)
+        self._draws = iter(draws)
+
+    def random(self) -> float:
+        return next(self._draws)
+
+
 class FixedActionPolicy:
     def __init__(self, source: str) -> None:
         self._source = source
@@ -160,28 +169,38 @@ def test_policy_uses_checkpoint_unless_random_is_forced(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    ("draw", "expected"),
-    ((0.1, "weighted"), (0.3, "uniform"), (0.8, "greedy")),
+    ("draws", "expected"),
+    (((0.1,), "weighted"), ((0.8, 0.1), "q_weighted"), ((0.8, 0.3), "greedy")),
 )
-def test_exploration_uses_ordered_weighted_uniform_and_greedy_intervals(
+def test_exploration_uses_random_then_model_weighting_as_independent_stages(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    draw: float,
+    draws: tuple[float, ...],
     expected: str,
 ) -> None:
     initialize_run("https://example.com", "testing", tmp_path, 13)
     config = load_config(tmp_path)
-    policy = InferencePolicy(tmp_path, config, FixedDrawRandom(draw))
+    policy = InferencePolicy(tmp_path, config, SequenceDrawRandom(*draws))
     policy._schedule = SimpleNamespace(  # type: ignore[assignment]
         probability=lambda **_values: ExplorationProbabilities(0.5, 0.2)
     )
     policy._weighted_random_policy = FixedActionPolicy("weighted")  # type: ignore[assignment]
-    policy._uniform_random_policy = FixedActionPolicy("uniform")  # type: ignore[assignment]
     policy._model = object()  # type: ignore[assignment]
     monkeypatch.setattr(
         policy,
-        "_model_action",
-        lambda *_args: Action(ActionKind.CLICK, 1, 1, source="greedy", channel="click"),
+        "_evaluate_model",
+        lambda *_args: (object(), {}),
+    )
+    monkeypatch.setattr(
+        policy,
+        "_action_from_output",
+        lambda *_args, weighted=False: Action(
+            ActionKind.CLICK,
+            1,
+            1,
+            source="q_weighted" if weighted else "greedy",
+            channel="click",
+        ),
     )
 
     selected = policy.select(_observation(), action_index=0, test_step_index=0, force_random=False)
@@ -196,17 +215,27 @@ def test_forced_random_always_uses_weighted_policy(
     config = load_config(tmp_path)
     policy = InferencePolicy(tmp_path, config, FixedDrawRandom(0.99))
     policy._weighted_random_policy = FixedActionPolicy("weighted")  # type: ignore[assignment]
-    policy._uniform_random_policy = FixedActionPolicy("uniform")  # type: ignore[assignment]
     policy._model = object()  # type: ignore[assignment]
-    monkeypatch.setattr(
-        policy,
-        "_model_action",
-        lambda *_args: Action(ActionKind.CLICK, 1, 1, source="greedy", channel="click"),
-    )
 
     selected = policy.select(_observation(), action_index=0, test_step_index=0, force_random=True)
 
     assert selected.source == "weighted"
+
+
+def test_model_weighted_exploration_samples_from_q_values(tmp_path: Path) -> None:
+    initialize_run("https://example.com", "testing", tmp_path, 15)
+    config = load_config(tmp_path)
+    policy = InferencePolicy(tmp_path, config, FixedDrawRandom(0.0))
+    values = torch.full(
+        (1, len(action_catalog(config.policy)), 1, 2),
+        torch.finfo(torch.float32).min,
+    )
+    values[0, 0, 0] = torch.tensor([1.0, 2.0])
+
+    selected = policy._action_from_output(_observation(), {"actionValues": values}, weighted=True)
+
+    assert selected.source == "weighted_random"
+    assert selected.x == 32
 
 
 def test_policy_rejects_a_corrupted_checkpoint_before_loading(tmp_path: Path) -> None:

--- a/tests/unit/test_recorded_samples.py
+++ b/tests/unit/test_recorded_samples.py
@@ -7,17 +7,26 @@ import torch
 
 from kwola.storage import AtomicBlobStore, LmdbRunStore
 from kwola.training.action_masks import action_masks
+from kwola.training.crop_selection import valid_next_crop
 from kwola.training.geometry import Crop, process_screenshot
 from kwola.training.image_cache import DecodedImageCache
 from kwola.training.sample_features import (
     _flood_reward,
     _paint_action_circle,
     coverage_symbols,
+    execution_features,
     recent_symbols,
     step_symbol_features,
     symbol_features,
 )
 from kwola.training.samples import ACTION_KINDS, RecordedSampleAssembler
+
+
+def test_execution_features_prefer_action_local_network_traffic() -> None:
+    trace = {"network_symbols": [10], "network_traffic": False}
+
+    assert execution_features(trace)[5] == 0.0
+    assert execution_features({"network_symbols": [10]})[5] == 1.0
 
 
 def test_recorded_samples_rebuild_from_trace_artifacts(tmp_path: Path) -> None:
@@ -208,6 +217,19 @@ def test_crop_local_action_masks_preserve_supported_target_fallback() -> None:
 
     assert not bool(action_masks(outside, (1920, 1080), None, crop=crop).any())
     assert bool(action_masks(unsupported, (1920, 1080), None, crop=crop).all())
+
+
+def test_next_crop_always_contains_a_valid_action() -> None:
+    trace = _trace(1, "unused.png")
+    trace["viewport"] = [1920, 1080]
+    trace["action"] = {"kind": "click", "x": 1700, "y": 800}
+    trace["action_targets"] = [
+        {"bounds": [1650, 750, 1800, 900], "click": True},
+    ]
+
+    crop = valid_next_crop(trace, 576, 324, 448, 320, None, random.Random(3))
+
+    assert bool(action_masks(trace, (576, 324), None, crop=crop).any())
 
 
 def test_decoded_image_cache_matches_live_grayscale_encoding(tmp_path: Path) -> None:

--- a/tests/unit/test_release_runtime_paths.py
+++ b/tests/unit/test_release_runtime_paths.py
@@ -442,7 +442,8 @@ def test_single_training_path_checkpoint_load_and_distributed_dispatch(
     run_dir = tmp_path / "single"
     initialize_run("https://example.com", "testing", run_dir, 21)
     with LmdbRunStore(run_dir / "run.lmdb") as store:
-        store.put("traces", "trace-1", {"screenshot": "unused"})
+        for index in range(4):
+            store.put("traces", f"trace-{index}", {"screenshot": "unused"})
     runner = TrainingRunner(run_dir, hooks=HookRegistry(()))
     monkeypatch.setattr(training_module, "TraceNet", FakeTrainingModel)
     monkeypatch.setattr(training_module, "ModelOptimizer", FakeTrainingOptimizer)

--- a/tests/unit/test_runtime_hardening.py
+++ b/tests/unit/test_runtime_hardening.py
@@ -19,7 +19,11 @@ from kwola.training import distributed as distributed_training
 from kwola.training.benchmark import run_benchmark
 from kwola.training.ddp import DistributedCoordinator, DistributedSettings
 from kwola.training.optimizer import OptimizerMetrics
-from kwola.training.replay import ReplaySampler
+from kwola.training.replay import (
+    ReplaySampler,
+    bounded_replay_iterations,
+    minimum_replay_size,
+)
 
 
 class FakeAssembler:
@@ -33,6 +37,14 @@ class FakeAssembler:
         if offset == self.failure_offset:
             raise ValueError("assembly failed")
         return offset
+
+
+def test_replay_training_is_bounded_to_one_duplicate_free_global_pass() -> None:
+    assert minimum_replay_size(batch_size=48, world_size=2) == 96
+    assert bounded_replay_iterations(95, 600, 48, 2) == 0
+    assert bounded_replay_iterations(96, 600, 48, 2) == 1
+    assert bounded_replay_iterations(240, 600, 48, 2) == 2
+    assert bounded_replay_iterations(240, 1, 48, 2) == 1
 
 
 def test_batch_stream_offsets_initial_batch_and_prefetch_failures() -> None:
@@ -298,7 +310,7 @@ def test_training_runner_iterations_state_record_and_dispatch(
         training_index=249,
         iteration_count=2,
     )
-    runner._record("training-00000000", metrics, 2)
+    runner._record("training-00000000", metrics, 2, 4)
     monkeypatch.setattr(
         runner,
         "_run_single",
@@ -314,6 +326,7 @@ def test_training_runner_iterations_state_record_and_dispatch(
     assert result.status == "completed"
     with LmdbRunStore(tmp_path / "run.lmdb", readonly=True) as store:
         assert store.get("run", "state")["training_iterations"] == 2  # type: ignore[index]
+        assert store.get("run", "state")["training_trace_count"] == 4  # type: ignore[index]
 
 
 def test_cpu_benchmark_executes_complete_optimizer_path(
@@ -363,10 +376,13 @@ def test_distributed_entry_validation_simulation_and_rank_recording(
         distributed_training.multiprocessing, "get_context", lambda _kind: FakeSpawnContext()
     )
     monkeypatch.setattr(distributed_training, "spawn", lambda *_args, **_values: None)
+    with LmdbRunStore(rig_run / "run.lmdb") as store:
+        for index in range(96):
+            store.put("traces", f"trace-{index}", {"index": index})
     assert distributed_training.run_distributed_training(rig_run).status == "completed"
 
     metrics = OptimizerMetrics(2.0, 4.0, 5.0)
-    distributed_training._record_step(rig_run, 0, 2.0, metrics, 3, 10.0, 1.0, 2.0, 0.5)
+    distributed_training._record_step(rig_run, 0, 2.0, metrics, 3, 96, 10.0, 1.0, 2.0, 0.5)
     with LmdbRunStore(rig_run / "run.lmdb", readonly=True) as store:
         record = store.get("training_steps", "training-00000000")
     assert record is not None and record["ranks"] == 2
@@ -376,11 +392,20 @@ def test_distributed_cache_and_iteration_helpers(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     initialize_run("https://example.com", "testing", tmp_path, 15)
-    with pytest.raises(RuntimeError, match="at least one"):
+    with pytest.raises(RuntimeError, match="at least 4"):
         distributed_training._prepare_cache(tmp_path)
     with LmdbRunStore(tmp_path / "run.lmdb") as store:
-        store.put("traces", "trace-1", {"screenshot": "unused"})
+        for index in range(4):
+            store.put("traces", f"trace-{index}", {"screenshot": "unused"})
     distributed_training._prepare_cache(tmp_path)
+    with LmdbRunStore(tmp_path / "run.lmdb") as store:
+        store.update(
+            "run",
+            "state",
+            lambda current: {**(current or {}), "training_trace_count": 4},
+        )
+    with pytest.raises(RuntimeError, match="at least 4"):
+        distributed_training._prepare_cache(tmp_path)
     assert (
         distributed_training._load_models(
             tmp_path,

--- a/tests/unit/test_trace_recorder.py
+++ b/tests/unit/test_trace_recorder.py
@@ -66,7 +66,7 @@ def test_trace_recorder_persists_features_blobs_and_bugs(tmp_path: Path) -> None
     assert len(tuple((tmp_path / "blobs" / "screenshots").iterdir())) == 3
 
 
-def test_campaign_coverage_claim_rewards_exactly_one_concurrent_trace(
+def test_session_rewards_are_independent_from_concurrent_campaign_claims(
     tmp_path: Path,
 ) -> None:
     initialize_run("https://example.com", "testing", tmp_path, 2)
@@ -97,8 +97,12 @@ def test_campaign_coverage_claim_rewards_exactly_one_concurrent_trace(
 
     assert len(coverage) == 1
     assert coverage[0][0] == "123456789abcdef0"
-    assert sorted(bool(trace["new_branch_symbols"]) for _key, trace in traces) == [False, True]
-    assert max(rewards) - min(rewards) == pytest.approx(config.policy.rewards.new_code_executed)
+    assert all(trace["new_branch_symbols"] for _key, trace in traces)
+    assert sorted(bool(trace["campaign_new_branch_symbols"]) for _key, trace in traces) == [
+        False,
+        True,
+    ]
+    assert rewards[0] == pytest.approx(rewards[1])
 
 
 def test_initial_page_coverage_is_claimed_without_action_reward(tmp_path: Path) -> None:
@@ -126,12 +130,52 @@ def test_initial_page_coverage_is_claimed_without_action_reward(tmp_path: Path) 
     assert reward < config.policy.rewards.new_code_executed
 
 
+def test_network_traffic_reward_is_scoped_to_the_action(tmp_path: Path) -> None:
+    initialize_run("https://example.com", "testing", tmp_path, 4)
+    config = load_config(tmp_path)
+    before = _observation(b"same", "https://example.com", (), (8,), network_events=1)
+    after = _observation(b"same", "https://example.com", (), (8,), network_events=2)
+    artifacts: list[str] = []
+    with LmdbRunStore(tmp_path / "run.lmdb", map_size=1024**2) as store:
+        recorder = TraceRecorder(tmp_path, config, store, artifacts)
+        novelty = NoveltyState.initial(before)
+        traffic_reward = recorder.record(
+            "testing-00000000",
+            0,
+            Action(ActionKind.CLICK, 2, 2),
+            before,
+            after,
+            novelty,
+            "pointer",
+            (None, None),
+        )
+        idle_reward = recorder.record(
+            "testing-00000000",
+            1,
+            Action(ActionKind.CLICK, 2, 2),
+            after,
+            after,
+            novelty,
+            "pointer",
+            (None, None),
+        )
+        traffic = store.get("traces", "testing-00000000-trace-0000")
+        idle = store.get("traces", "testing-00000000-trace-0001")
+
+    assert traffic is not None and idle is not None
+    assert traffic["network_traffic"] is True
+    assert traffic["new_network_symbols"] == []
+    assert idle["network_traffic"] is False
+    assert traffic_reward - idle_reward == pytest.approx(config.policy.rewards.network_traffic)
+
+
 def _observation(
     screenshot: bytes,
     url: str,
     branches: tuple[int, ...],
     network: tuple[int, ...],
     errors: tuple[str, ...] = (),
+    network_events: int | None = None,
     fitness: float | None = None,
 ) -> Observation:
     target = ActionTarget(0, 0, 10, 10, "button", can_click=True)
@@ -148,5 +192,6 @@ def _observation(
         ("message",),
         errors,
         True,
+        network_event_count=len(network) if network_events is None else network_events,
         application_fitness=fitness,
     )


### PR DESCRIPTION
Summary:
- gate replay training on fresh global batches and persist the trained trace high-water mark
- preserve valid next-state crops and add conservative-Q regularization
- correct exploration and reward-recording semantics
- update all first-party learning documentation and acceptance evidence

Verification:
- Ruff format and lint
- strict mypy across 94 source files
- 194 unit, characterization, and architecture tests
- 87.44% branch-aware coverage