### PR TITLE
Prevent conservative Q loss overflow

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,8 @@
   target instead of selecting an invalid flattened cell.
 - The loss now includes a configurable conservative-Q margin penalty for unsupported valid actions,
   enabled by default with weight and margin `0.1`. Its contribution is recorded as
-  `conservative_q_loss` in training results, stored training records, and progress telemetry.
+  `conservative_q_loss` in training results, stored training records, and progress telemetry. Masked
+  action sentinels are excluded from its differentiable-zero term to prevent floating-point overflow.
 - Exploration now uses independent stages: `random` controls action-catalog-weighted behavior that
   bypasses inference, while `weighted_random` conditionally selects Q-weighted sampling after model
   evaluation. These settings are no longer ordered thresholds, and the uniform-random interval has

--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -103,7 +103,7 @@ cadence and do not prove the new learning-hardening requirements.
 
 After the replay, crop-validity, and conservative-Q changes, the macOS working tree passed Ruff
 formatting and linting, strict mypy over 94 Python sources, and the non-network unit,
-characterization, and architecture suite: 194 passed with 87.44% branch-aware coverage. Four
+characterization, and architecture suite: 195 passed with 87.44% branch-aware coverage. Four
 full-suite integration cases that bind local listening sockets could not execute in the restricted
 local sandbox. This is local correctness evidence only; it does not replace the required fresh Linux
 rig acceptance run or its two-GPU/browser performance evidence.

--- a/kwola/training/losses.py
+++ b/kwola/training/losses.py
@@ -113,11 +113,11 @@ def _conservative_q_loss(
 ) -> Tensor:
     """Keep unsupported valid actions below the demonstrated action value."""
     values = outputs["actionValues"]
-    zero = values.sum() * 0
+    valid = batch.request.pixel_action_maps > 0
+    zero = values.masked_select(valid).sum() * 0
     if weights.conservative_q == 0:
         return zero
 
-    valid = batch.request.pixel_action_maps > 0
     indexes = torch.arange(len(batch.sample_ids), device=values.device)
     demonstrated = torch.zeros_like(valid)
     demonstrated_region = (

--- a/tests/characterization/test_legacy_loss.py
+++ b/tests/characterization/test_legacy_loss.py
@@ -113,6 +113,33 @@ def test_conservative_q_margin_lowers_the_best_unsupported_action() -> None:
     assert values.grad[1, 1, 0, 0] == 0
 
 
+def test_conservative_q_zero_term_ignores_masked_value_sentinels() -> None:
+    config = profile_config("testing", "https://example.com", 1)
+    batch = _batch(torch.tensor([False, False]))
+    valid = torch.zeros_like(batch.request.pixel_action_maps)
+    valid[0, 0, 0, 0] = 1
+    valid[0, 1, 0, 1] = 1
+    valid[1, 1, 0, 0] = 1
+    valid[1, 0, 0, 1] = 1
+    batch = replace(batch, request=replace(batch.request, pixel_action_maps=valid))
+    values = torch.full(
+        valid.shape,
+        torch.finfo(torch.float32).min,
+        requires_grad=True,
+    )
+    with torch.no_grad():
+        values[valid.bool()] = 0
+
+    loss = _conservative_q_loss(
+        {"actionValues": values}, batch, torch.zeros(2), config.training.losses
+    )
+    loss.backward()
+
+    assert torch.isfinite(loss)
+    assert values.grad is not None
+    assert torch.isfinite(values.grad).all()
+
+
 def test_present_reward_trains_on_terminal_and_only_recorded_region() -> None:
     config = profile_config("testing", "https://example.com", 1)
     present = torch.zeros(2, 2, 8, 8, requires_grad=True)


### PR DESCRIPTION
Summary:
- exclude masked action sentinels from the conservative-Q differentiable-zero term
- add a regression test matching the live masked action map
- update changelog and acceptance evidence

Verification:
- Ruff format and lint
- strict mypy across 94 source files
- 195 unit, characterization, and architecture tests
- 87.44% branch-aware coverage
- live rig reproduction identified the original NaN path